### PR TITLE
docs: add `read-all` usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ blogwatcher read 42
 
 # Mark an article as unread
 blogwatcher unread 42
+
+# Mark all unread articles as read
+blogwatcher read-all
+
+# Mark all unread articles as read for a blog (skip prompt)
+blogwatcher read-all --blog "Tech Blog" --yes
 ```
 
 ## How It Works


### PR DESCRIPTION
### Motivation
- The README did not document the `read-all` CLI option, making the command hard to discover.
- Adding usage examples improves UX for marking all unread articles as read and clarifies available flags.

### Description
- Updated `README.md` to add a `read-all` example in the "Managing Read Status" section.
- Included examples for `blogwatcher read-all` and `blogwatcher read-all --blog "Tech Blog" --yes`.
- This change is documentation-only and does not modify application code.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a602d439c83318ba10dff81a2ae37)