### PR TITLE
Fix critical security issues: SSRF, body limits, DB permissions

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"fmt"
 
+	"github.com/Hyaxia/blogwatcher/internal/httputil"
 	"github.com/Hyaxia/blogwatcher/internal/model"
 	"github.com/Hyaxia/blogwatcher/internal/storage"
 )
@@ -33,6 +34,15 @@ func (e ArticleNotFoundError) Error() string {
 }
 
 func AddBlog(db *storage.Database, name string, url string, feedURL string, scrapeSelector string) (model.Blog, error) {
+	if err := httputil.ValidateURL(url); err != nil {
+		return model.Blog{}, fmt.Errorf("invalid blog URL: %w", err)
+	}
+	if feedURL != "" {
+		if err := httputil.ValidateURL(feedURL); err != nil {
+			return model.Blog{}, fmt.Errorf("invalid feed URL: %w", err)
+		}
+	}
+
 	if existing, err := db.GetBlogByName(name); err != nil {
 		return model.Blog{}, err
 	} else if existing != nil {

--- a/internal/httputil/httputil.go
+++ b/internal/httputil/httputil.go
@@ -1,0 +1,107 @@
+package httputil
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// MaxBodySize is the default maximum response body size (10 MB).
+const MaxBodySize int64 = 10 * 1024 * 1024
+
+const maxRedirects = 5
+
+// AllowPrivate disables private/reserved IP blocking. This should only be set
+// to true in tests that use httptest.Server on localhost.
+var AllowPrivate bool
+
+// privateRanges contains CIDR blocks for private/reserved IP ranges.
+var privateRanges []*net.IPNet
+
+func init() {
+	cidrs := []string{
+		"127.0.0.0/8",
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"169.254.0.0/16",
+		"::1/128",
+		"fc00::/7",
+	}
+	for _, cidr := range cidrs {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(fmt.Sprintf("httputil: bad CIDR %q: %v", cidr, err))
+		}
+		privateRanges = append(privateRanges, network)
+	}
+}
+
+// ValidateURL checks that a URL uses http/https and does not resolve to a
+// private or reserved IP address.
+func ValidateURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+
+	switch parsed.Scheme {
+	case "http", "https":
+	default:
+		return fmt.Errorf("unsupported URL scheme %q: only http and https are allowed", parsed.Scheme)
+	}
+
+	hostname := parsed.Hostname()
+	if hostname == "" {
+		return fmt.Errorf("URL has no hostname")
+	}
+
+	ips, err := net.LookupIP(hostname)
+	if err != nil {
+		return fmt.Errorf("failed to resolve hostname %q: %w", hostname, err)
+	}
+
+	if !AllowPrivate {
+		for _, ip := range ips {
+			if isPrivateIP(ip) {
+				return fmt.Errorf("URL resolves to private/reserved address %s", ip)
+			}
+		}
+	}
+
+	return nil
+}
+
+func isPrivateIP(ip net.IP) bool {
+	for _, network := range privateRanges {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// SafeClient returns an *http.Client with the given timeout that validates
+// redirect targets against SSRF, limiting redirects to 5.
+func SafeClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= maxRedirects {
+				return fmt.Errorf("stopped after %d redirects", maxRedirects)
+			}
+			if err := ValidateURL(req.URL.String()); err != nil {
+				return fmt.Errorf("redirect blocked: %w", err)
+			}
+			return nil
+		},
+	}
+}
+
+// LimitBody wraps a reader to cap the number of bytes read to MaxBodySize.
+func LimitBody(r io.Reader) io.Reader {
+	return io.LimitReader(r, MaxBodySize)
+}

--- a/internal/httputil/httputil_test.go
+++ b/internal/httputil/httputil_test.go
@@ -1,0 +1,115 @@
+package httputil
+
+import (
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateURL_BlocksPrivateIPs(t *testing.T) {
+	blocked := []string{
+		"http://127.0.0.1",
+		"http://127.0.0.1:8080",
+		"http://10.0.0.1",
+		"http://172.16.0.1",
+		"http://192.168.1.1",
+		"http://169.254.169.254", // cloud metadata
+		"http://[::1]",
+	}
+	for _, u := range blocked {
+		if err := ValidateURL(u); err == nil {
+			t.Errorf("ValidateURL(%q) should have been blocked", u)
+		}
+	}
+}
+
+func TestValidateURL_AllowsPublicURLs(t *testing.T) {
+	allowed := []string{
+		"https://example.com",
+		"http://example.com/feed.xml",
+		"https://example.org/rss",
+	}
+	for _, u := range allowed {
+		if err := ValidateURL(u); err != nil {
+			t.Errorf("ValidateURL(%q) should be allowed, got: %v", u, err)
+		}
+	}
+}
+
+func TestValidateURL_BlocksNonHTTPSchemes(t *testing.T) {
+	blocked := []string{
+		"ftp://example.com",
+		"file:///etc/passwd",
+		"gopher://example.com",
+		"javascript:alert(1)",
+	}
+	for _, u := range blocked {
+		err := ValidateURL(u)
+		if err == nil {
+			t.Errorf("ValidateURL(%q) should have been blocked", u)
+			continue
+		}
+		if !strings.Contains(err.Error(), "unsupported URL scheme") {
+			t.Errorf("ValidateURL(%q) error should mention scheme, got: %v", u, err)
+		}
+	}
+}
+
+func TestValidateURL_RejectsEmptyHostname(t *testing.T) {
+	err := ValidateURL("http://")
+	if err == nil {
+		t.Error("ValidateURL with empty hostname should fail")
+	}
+}
+
+func TestSafeClient_ReturnsClientWithTimeout(t *testing.T) {
+	client := SafeClient(5 * time.Second)
+	if client == nil {
+		t.Fatal("SafeClient returned nil")
+	}
+	if client.Timeout != 5*time.Second {
+		t.Errorf("expected timeout 5s, got %v", client.Timeout)
+	}
+	if client.CheckRedirect == nil {
+		t.Error("SafeClient should set CheckRedirect")
+	}
+}
+
+func TestLimitBody_LimitsRead(t *testing.T) {
+	data := strings.NewReader(strings.Repeat("a", 100))
+	limited := LimitBody(data)
+
+	buf := make([]byte, 200)
+	n, _ := limited.Read(buf)
+	if n != 100 {
+		t.Errorf("expected to read 100 bytes, got %d", n)
+	}
+}
+
+func TestIsPrivateIP_Coverage(t *testing.T) {
+	tests := []struct {
+		addr    string
+		private bool
+	}{
+		{"127.0.0.1", true},
+		{"10.255.255.255", true},
+		{"172.16.0.0", true},
+		{"172.31.255.255", true},
+		{"172.32.0.0", false},
+		{"192.168.0.1", true},
+		{"169.254.1.1", true},
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+	}
+	for _, tt := range tests {
+		ip := net.ParseIP(tt.addr)
+		if ip == nil {
+			t.Fatalf("failed to parse IP %q", tt.addr)
+		}
+		got := isPrivateIP(ip)
+		if got != tt.private {
+			t.Errorf("isPrivateIP(%s) = %v, want %v", tt.addr, got, tt.private)
+		}
+	}
+}

--- a/internal/rss/rss.go
+++ b/internal/rss/rss.go
@@ -3,13 +3,14 @@ package rss
 import (
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/mmcdole/gofeed"
+
+	"github.com/Hyaxia/blogwatcher/internal/httputil"
 )
 
 type FeedArticle struct {
@@ -27,7 +28,11 @@ func (e FeedParseError) Error() string {
 }
 
 func ParseFeed(feedURL string, timeout time.Duration) ([]FeedArticle, error) {
-	client := &http.Client{Timeout: timeout}
+	if err := httputil.ValidateURL(feedURL); err != nil {
+		return nil, FeedParseError{Message: fmt.Sprintf("blocked URL: %v", err)}
+	}
+
+	client := httputil.SafeClient(timeout)
 	response, err := client.Get(feedURL)
 	if err != nil {
 		return nil, FeedParseError{Message: fmt.Sprintf("failed to fetch feed: %v", err)}
@@ -38,7 +43,7 @@ func ParseFeed(feedURL string, timeout time.Duration) ([]FeedArticle, error) {
 	}
 
 	parser := gofeed.NewParser()
-	feed, err := parser.Parse(response.Body)
+	feed, err := parser.Parse(httputil.LimitBody(response.Body))
 	if err != nil {
 		return nil, FeedParseError{Message: fmt.Sprintf("failed to parse feed: %v", err)}
 	}
@@ -61,7 +66,11 @@ func ParseFeed(feedURL string, timeout time.Duration) ([]FeedArticle, error) {
 }
 
 func DiscoverFeedURL(blogURL string, timeout time.Duration) (string, error) {
-	client := &http.Client{Timeout: timeout}
+	if err := httputil.ValidateURL(blogURL); err != nil {
+		return "", fmt.Errorf("blocked URL: %w", err)
+	}
+
+	client := httputil.SafeClient(timeout)
 	response, err := client.Get(blogURL)
 	if err != nil {
 		return "", nil
@@ -76,7 +85,7 @@ func DiscoverFeedURL(blogURL string, timeout time.Duration) (string, error) {
 		return "", nil
 	}
 
-	doc, err := goquery.NewDocumentFromReader(response.Body)
+	doc, err := goquery.NewDocumentFromReader(httputil.LimitBody(response.Body))
 	if err != nil {
 		return "", nil
 	}
@@ -130,18 +139,22 @@ func DiscoverFeedURL(blogURL string, timeout time.Duration) (string, error) {
 }
 
 func isValidFeed(feedURL string, timeout time.Duration) (bool, error) {
-	client := &http.Client{Timeout: timeout}
+	if err := httputil.ValidateURL(feedURL); err != nil {
+		return false, err
+	}
+
+	client := httputil.SafeClient(timeout)
 	response, err := client.Get(feedURL)
 	if err != nil {
 		return false, err
 	}
 	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK {
+	if response.StatusCode != 200 {
 		return false, nil
 	}
 
 	parser := gofeed.NewParser()
-	feed, err := parser.Parse(response.Body)
+	feed, err := parser.Parse(httputil.LimitBody(response.Body))
 	if err != nil {
 		return false, err
 	}

--- a/internal/rss/rss_test.go
+++ b/internal/rss/rss_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/Hyaxia/blogwatcher/internal/httputil"
 )
 
 const sampleFeed = `<?xml version="1.0" encoding="UTF-8" ?>
@@ -24,6 +26,8 @@ const sampleFeed = `<?xml version="1.0" encoding="UTF-8" ?>
 </rss>`
 
 func TestParseFeed(t *testing.T) {
+	httputil.AllowPrivate = true
+	t.Cleanup(func() { httputil.AllowPrivate = false })
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(sampleFeed))
@@ -43,6 +47,8 @@ func TestParseFeed(t *testing.T) {
 }
 
 func TestDiscoverFeedURL(t *testing.T) {
+	httputil.AllowPrivate = true
+	t.Cleanup(func() { httputil.AllowPrivate = false })
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Hyaxia/blogwatcher/internal/httputil"
 	"github.com/Hyaxia/blogwatcher/internal/model"
 	"github.com/Hyaxia/blogwatcher/internal/storage"
 )
@@ -27,6 +28,8 @@ const sampleFeed = `<?xml version="1.0" encoding="UTF-8" ?>
 </rss>`
 
 func TestScanBlogRSS(t *testing.T) {
+	httputil.AllowPrivate = true
+	t.Cleanup(func() { httputil.AllowPrivate = false })
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(sampleFeed))
@@ -59,6 +62,8 @@ func TestScanBlogRSS(t *testing.T) {
 }
 
 func TestScanBlogScraperFallback(t *testing.T) {
+	httputil.AllowPrivate = true
+	t.Cleanup(func() { httputil.AllowPrivate = false })
 	html := `<!DOCTYPE html>
 <html>
 <body>
@@ -98,6 +103,8 @@ func TestScanBlogScraperFallback(t *testing.T) {
 }
 
 func TestScanAllBlogsConcurrent(t *testing.T) {
+	httputil.AllowPrivate = true
+	t.Cleanup(func() { httputil.AllowPrivate = false })
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(sampleFeed))
@@ -134,6 +141,8 @@ func openTestDB(t *testing.T) *storage.Database {
 }
 
 func TestScanBlogRespectsExistingArticles(t *testing.T) {
+	httputil.AllowPrivate = true
+	t.Cleanup(func() { httputil.AllowPrivate = false })
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(sampleFeed))

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -3,12 +3,13 @@ package scraper
 import (
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
+
+	"github.com/Hyaxia/blogwatcher/internal/httputil"
 )
 
 type ScrapedArticle struct {
@@ -26,7 +27,11 @@ func (e ScrapeError) Error() string {
 }
 
 func ScrapeBlog(blogURL string, selector string, timeout time.Duration) ([]ScrapedArticle, error) {
-	client := &http.Client{Timeout: timeout}
+	if err := httputil.ValidateURL(blogURL); err != nil {
+		return nil, ScrapeError{Message: fmt.Sprintf("blocked URL: %v", err)}
+	}
+
+	client := httputil.SafeClient(timeout)
 	response, err := client.Get(blogURL)
 	if err != nil {
 		return nil, ScrapeError{Message: fmt.Sprintf("failed to fetch page: %v", err)}
@@ -41,7 +46,7 @@ func ScrapeBlog(blogURL string, selector string, timeout time.Duration) ([]Scrap
 		return nil, ScrapeError{Message: "invalid blog url"}
 	}
 
-	doc, err := goquery.NewDocumentFromReader(response.Body)
+	doc, err := goquery.NewDocumentFromReader(httputil.LimitBody(response.Body))
 	if err != nil {
 		return nil, ScrapeError{Message: fmt.Sprintf("failed to parse page: %v", err)}
 	}

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -5,9 +5,13 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/Hyaxia/blogwatcher/internal/httputil"
 )
 
 func TestScrapeBlog(t *testing.T) {
+	httputil.AllowPrivate = true
+	t.Cleanup(func() { httputil.AllowPrivate = false })
 	html := `<!DOCTYPE html>
 <html>
 <body>

--- a/internal/storage/database.go
+++ b/internal/storage/database.go
@@ -38,8 +38,17 @@ func OpenDatabase(path string) (*Database, error) {
 		}
 	}
 
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, err
+	}
+
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("database directory is a symlink: %s", dir)
 	}
 
 	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)", path)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "dev"
+var Version = "dev-marcind"


### PR DESCRIPTION
## Summary

- **SSRF protection** — new `internal/httputil` package with `ValidateURL` (blocks private/reserved IPs, non-http schemes) and `SafeClient` (validates redirect targets, caps redirects at 5)
- **Response body limits** — all HTTP response bodies capped at 10 MB via `httputil.LimitBody` to prevent memory exhaustion
- **Database directory permissions** — tightened from `0755` to `0700`, added symlink check to prevent path traversal

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go vet ./...` passes
- [x] `go test ./...` — all existing and new tests pass
- [ ] Manual: `go run ./cmd/blogwatcher add test http://127.0.0.1:8080` should be rejected
- [ ] Manual: `go run ./cmd/blogwatcher add test ftp://example.com` should be rejected
- [ ] Manual: `go run ./cmd/blogwatcher add test https://example.com` should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)