### PR TITLE
feat: add custom user-agent support for feed and scrape requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ blogwatcher scan
 
 # Scan a specific blog
 blogwatcher scan "Tech Blog"
+
+# Scan with a custom User-Agent (useful when sites block default Go UA)
+blogwatcher --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36" scan
 ```
 
 ### Viewing Articles

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,19 +4,26 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Hyaxia/blogwatcher/internal/scanner"
 	"github.com/Hyaxia/blogwatcher/internal/version"
 	"github.com/spf13/cobra"
 )
 
 func NewRootCommand() *cobra.Command {
+	var userAgent string
+
 	rootCmd := &cobra.Command{
 		Use:           "blogwatcher",
 		Short:         "BlogWatcher - Track blog articles and detect new posts.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			scanner.SetHTTPUserAgent(userAgent)
+		},
 	}
 	rootCmd.Version = version.Version
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
+	rootCmd.PersistentFlags().StringVar(&userAgent, "user-agent", "", "Custom HTTP User-Agent for feed/scrape requests")
 	rootCmd.AddCommand(newAddCommand())
 	rootCmd.AddCommand(newRemoveCommand())
 	rootCmd.AddCommand(newBlogsCommand())

--- a/internal/rss/rss.go
+++ b/internal/rss/rss.go
@@ -26,9 +26,9 @@ func (e FeedParseError) Error() string {
 	return e.Message
 }
 
-func ParseFeed(feedURL string, timeout time.Duration) ([]FeedArticle, error) {
+func ParseFeed(feedURL string, timeout time.Duration, userAgent string) ([]FeedArticle, error) {
 	client := &http.Client{Timeout: timeout}
-	response, err := client.Get(feedURL)
+	response, err := getWithOptionalUserAgent(client, feedURL, userAgent)
 	if err != nil {
 		return nil, FeedParseError{Message: fmt.Sprintf("failed to fetch feed: %v", err)}
 	}
@@ -60,9 +60,9 @@ func ParseFeed(feedURL string, timeout time.Duration) ([]FeedArticle, error) {
 	return articles, nil
 }
 
-func DiscoverFeedURL(blogURL string, timeout time.Duration) (string, error) {
+func DiscoverFeedURL(blogURL string, timeout time.Duration, userAgent string) (string, error) {
 	client := &http.Client{Timeout: timeout}
-	response, err := client.Get(blogURL)
+	response, err := getWithOptionalUserAgent(client, blogURL, userAgent)
 	if err != nil {
 		return "", nil
 	}
@@ -120,7 +120,7 @@ func DiscoverFeedURL(blogURL string, timeout time.Duration) (string, error) {
 		if resolved == "" {
 			continue
 		}
-		ok, err := isValidFeed(resolved, timeout)
+		ok, err := isValidFeed(resolved, timeout, userAgent)
 		if err == nil && ok {
 			return resolved, nil
 		}
@@ -129,9 +129,9 @@ func DiscoverFeedURL(blogURL string, timeout time.Duration) (string, error) {
 	return "", nil
 }
 
-func isValidFeed(feedURL string, timeout time.Duration) (bool, error) {
+func isValidFeed(feedURL string, timeout time.Duration, userAgent string) (bool, error) {
 	client := &http.Client{Timeout: timeout}
-	response, err := client.Get(feedURL)
+	response, err := getWithOptionalUserAgent(client, feedURL, userAgent)
 	if err != nil {
 		return false, err
 	}
@@ -147,6 +147,17 @@ func isValidFeed(feedURL string, timeout time.Duration) (bool, error) {
 	}
 
 	return len(feed.Items) > 0 || strings.TrimSpace(feed.Title) != "", nil
+}
+
+func getWithOptionalUserAgent(client *http.Client, targetURL string, userAgent string) (*http.Response, error) {
+	request, err := http.NewRequest(http.MethodGet, targetURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(userAgent) != "" {
+		request.Header.Set("User-Agent", userAgent)
+	}
+	return client.Do(request)
 }
 
 func resolveURL(base *url.URL, href string) string {

--- a/internal/rss/rss_test.go
+++ b/internal/rss/rss_test.go
@@ -30,7 +30,7 @@ func TestParseFeed(t *testing.T) {
 	}))
 	defer server.Close()
 
-	articles, err := ParseFeed(server.URL, 2*time.Second)
+	articles, err := ParseFeed(server.URL, 2*time.Second, "")
 	if err != nil {
 		t.Fatalf("parse feed: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestDiscoverFeedURL(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	feedURL, err := DiscoverFeedURL(server.URL, 2*time.Second)
+	feedURL, err := DiscoverFeedURL(server.URL, 2*time.Second, "")
 	if err != nil {
 		t.Fatalf("discover feed: %v", err)
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Hyaxia/blogwatcher/internal/model"
@@ -18,6 +19,12 @@ type ScanResult struct {
 	Error       string
 }
 
+var httpUserAgent string
+
+func SetHTTPUserAgent(userAgent string) {
+	httpUserAgent = strings.TrimSpace(userAgent)
+}
+
 func ScanBlog(db *storage.Database, blog model.Blog) ScanResult {
 	var (
 		articles []model.Article
@@ -27,7 +34,7 @@ func ScanBlog(db *storage.Database, blog model.Blog) ScanResult {
 
 	feedURL := blog.FeedURL
 	if feedURL == "" {
-		if discovered, err := rss.DiscoverFeedURL(blog.URL, 30*time.Second); err == nil && discovered != "" {
+		if discovered, err := rss.DiscoverFeedURL(blog.URL, 30*time.Second, httpUserAgent); err == nil && discovered != "" {
 			feedURL = discovered
 			blog.FeedURL = discovered
 			_ = db.UpdateBlog(blog)
@@ -35,7 +42,7 @@ func ScanBlog(db *storage.Database, blog model.Blog) ScanResult {
 	}
 
 	if feedURL != "" {
-		feedArticles, err := rss.ParseFeed(feedURL, 30*time.Second)
+		feedArticles, err := rss.ParseFeed(feedURL, 30*time.Second, httpUserAgent)
 		if err != nil {
 			errText = err.Error()
 		} else {
@@ -45,7 +52,7 @@ func ScanBlog(db *storage.Database, blog model.Blog) ScanResult {
 	}
 
 	if len(articles) == 0 && blog.ScrapeSelector != "" {
-		scrapedArticles, err := scraper.ScrapeBlog(blog.URL, blog.ScrapeSelector, 30*time.Second)
+		scrapedArticles, err := scraper.ScrapeBlog(blog.URL, blog.ScrapeSelector, 30*time.Second, httpUserAgent)
 		if err != nil {
 			if errText != "" {
 				errText = fmt.Sprintf("RSS: %s; Scraper: %s", errText, err.Error())

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -25,9 +25,9 @@ func (e ScrapeError) Error() string {
 	return e.Message
 }
 
-func ScrapeBlog(blogURL string, selector string, timeout time.Duration) ([]ScrapedArticle, error) {
+func ScrapeBlog(blogURL string, selector string, timeout time.Duration, userAgent string) ([]ScrapedArticle, error) {
 	client := &http.Client{Timeout: timeout}
-	response, err := client.Get(blogURL)
+	response, err := getWithOptionalUserAgent(client, blogURL, userAgent)
 	if err != nil {
 		return nil, ScrapeError{Message: fmt.Sprintf("failed to fetch page: %v", err)}
 	}
@@ -101,6 +101,17 @@ func extractTitle(link *goquery.Selection, parent *goquery.Selection) string {
 		}
 	}
 	return ""
+}
+
+func getWithOptionalUserAgent(client *http.Client, targetURL string, userAgent string) (*http.Response, error) {
+	request, err := http.NewRequest(http.MethodGet, targetURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(userAgent) != "" {
+		request.Header.Set("User-Agent", userAgent)
+	}
+	return client.Do(request)
 }
 
 func resolveURL(base *url.URL, href string) string {

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -23,7 +23,7 @@ func TestScrapeBlog(t *testing.T) {
 	}))
 	defer server.Close()
 
-	articles, err := ScrapeBlog(server.URL, "article h2 a, .post", 2*time.Second)
+	articles, err := ScrapeBlog(server.URL, "article h2 a, .post", 2*time.Second, "")
 	if err != nil {
 		t.Fatalf("scrape blog: %v", err)
 	}


### PR DESCRIPTION
## Summary
- add a new global CLI flag: `--user-agent`
- propagate the custom User-Agent to RSS fetch/discovery and HTML scraper fetches
- keep default behavior unchanged when the flag is not set

## Why
Some feeds/sites block Go's default HTTP User-Agent and return 403 or anti-bot pages. This makes valid RSS URLs fail in practice.

## Changes
- `internal/cli/root.go`
  - add persistent flag `--user-agent`
  - set scanner-level user-agent in `PersistentPreRun`
- `internal/scanner/scanner.go`
  - add `SetHTTPUserAgent(...)` and pass user-agent to rss/scraper calls
- `internal/rss/rss.go`
  - update `ParseFeed`, `DiscoverFeedURL`, and feed validation helpers to accept `userAgent`
  - use request-based GET with optional header override
- `internal/scraper/scraper.go`
  - update `ScrapeBlog` to accept `userAgent`
  - use request-based GET with optional header override
- update tests to match new function signatures

## Verification
- `go test ./...` passes
- local binary shows new flag in help output
