### PR TITLE
feat: support per-blog User-Agent overrides for feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ blogwatcher add "Tech Blog" https://techblog.com --feed-url https://techblog.com
 
 # Add with HTML scraping selector (for blogs without feeds)
 blogwatcher add "No-RSS Blog" https://norss.com --scrape-selector "article h2 a"
+
+# Add with per-blog User-Agent override
+blogwatcher add "Blocked Blog" https://blocked.example --feed-url https://blocked.example/feed --user-agent "Mozilla/5.0 ..."
 ```
 
 ### Managing Blogs
@@ -63,7 +66,7 @@ blogwatcher scan
 # Scan a specific blog
 blogwatcher scan "Tech Blog"
 
-# Scan with a custom User-Agent (useful when sites block default Go UA)
+# Scan with a global User-Agent fallback (used when a blog has no per-blog --user-agent)
 blogwatcher --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36" scan
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ blogwatcher scan
 
 # Scan a specific blog
 blogwatcher scan "Tech Blog"
+
+# Scan with a custom User-Agent (useful when sites block default Go UA)
+blogwatcher --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36" scan
 ```
 
 ### Viewing Articles

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ blogwatcher scan
 # Scan a specific blog
 blogwatcher scan "Tech Blog"
 
-# Scan with a global User-Agent fallback (used when a blog has no per-blog --user-agent)
-blogwatcher --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36" scan
+# Per-blog User-Agent is configured at add time via --user-agent
+# Example above: blogwatcher add ... --user-agent "Mozilla/5.0 ..."
 ```
 
 ### Viewing Articles

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -20,6 +20,7 @@ import (
 func newAddCommand() *cobra.Command {
 	var feedURL string
 	var scrapeSelector string
+	var userAgent string
 
 	cmd := &cobra.Command{
 		Use:   "add <name> <url>",
@@ -33,7 +34,7 @@ func newAddCommand() *cobra.Command {
 				return err
 			}
 			defer db.Close()
-			_, err = controller.AddBlog(db, name, url, feedURL, scrapeSelector)
+			_, err = controller.AddBlog(db, name, url, feedURL, scrapeSelector, userAgent)
 			if err != nil {
 				printError(err)
 				return markError(err)
@@ -44,6 +45,7 @@ func newAddCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&feedURL, "feed-url", "", "RSS/Atom feed URL (auto-discovered if not provided)")
 	cmd.Flags().StringVar(&scrapeSelector, "scrape-selector", "", "CSS selector for HTML scraping fallback")
+	cmd.Flags().StringVar(&userAgent, "user-agent", "", "Per-blog HTTP User-Agent override")
 	return cmd
 }
 
@@ -108,6 +110,9 @@ func newBlogsCommand() *cobra.Command {
 				}
 				if blog.ScrapeSelector != "" {
 					fmt.Printf("    Selector: %s\n", blog.ScrapeSelector)
+				}
+				if blog.UserAgent != "" {
+					fmt.Printf("    User-Agent: %s\n", blog.UserAgent)
 				}
 				if blog.LastScanned != nil {
 					fmt.Printf("    Last scanned: %s\n", blog.LastScanned.Format("2006-01-02 15:04"))

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,19 +4,26 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Hyaxia/blogwatcher/internal/scanner"
 	"github.com/Hyaxia/blogwatcher/internal/version"
 	"github.com/spf13/cobra"
 )
 
 func NewRootCommand() *cobra.Command {
+	var userAgent string
+
 	rootCmd := &cobra.Command{
 		Use:           "blogwatcher",
 		Short:         "BlogWatcher - Track blog articles and detect new posts.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			scanner.SetHTTPUserAgent(userAgent)
+		},
 	}
 	rootCmd.Version = version.Version
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
+	rootCmd.PersistentFlags().StringVar(&userAgent, "user-agent", "", "Custom HTTP User-Agent for feed/scrape requests")
 	rootCmd.AddCommand(newAddCommand())
 	rootCmd.AddCommand(newRemoveCommand())
 	rootCmd.AddCommand(newBlogsCommand())

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,26 +4,19 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Hyaxia/blogwatcher/internal/scanner"
 	"github.com/Hyaxia/blogwatcher/internal/version"
 	"github.com/spf13/cobra"
 )
 
 func NewRootCommand() *cobra.Command {
-	var userAgent string
-
 	rootCmd := &cobra.Command{
 		Use:           "blogwatcher",
 		Short:         "BlogWatcher - Track blog articles and detect new posts.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			scanner.SetHTTPUserAgent(userAgent)
-		},
 	}
 	rootCmd.Version = version.Version
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
-	rootCmd.PersistentFlags().StringVar(&userAgent, "user-agent", "", "Global HTTP User-Agent fallback for feed/scrape requests")
 	rootCmd.AddCommand(newAddCommand())
 	rootCmd.AddCommand(newRemoveCommand())
 	rootCmd.AddCommand(newBlogsCommand())

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -23,7 +23,7 @@ func NewRootCommand() *cobra.Command {
 	}
 	rootCmd.Version = version.Version
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
-	rootCmd.PersistentFlags().StringVar(&userAgent, "user-agent", "", "Custom HTTP User-Agent for feed/scrape requests")
+	rootCmd.PersistentFlags().StringVar(&userAgent, "user-agent", "", "Global HTTP User-Agent fallback for feed/scrape requests")
 	rootCmd.AddCommand(newAddCommand())
 	rootCmd.AddCommand(newRemoveCommand())
 	rootCmd.AddCommand(newBlogsCommand())

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -32,7 +32,7 @@ func (e ArticleNotFoundError) Error() string {
 	return fmt.Sprintf("Article %d not found", e.ID)
 }
 
-func AddBlog(db *storage.Database, name string, url string, feedURL string, scrapeSelector string) (model.Blog, error) {
+func AddBlog(db *storage.Database, name string, url string, feedURL string, scrapeSelector string, userAgent string) (model.Blog, error) {
 	if existing, err := db.GetBlogByName(name); err != nil {
 		return model.Blog{}, err
 	} else if existing != nil {
@@ -49,6 +49,7 @@ func AddBlog(db *storage.Database, name string, url string, feedURL string, scra
 		URL:            url,
 		FeedURL:        feedURL,
 		ScrapeSelector: scrapeSelector,
+		UserAgent:      userAgent,
 	}
 	return db.AddBlog(blog)
 }

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -12,16 +12,16 @@ func TestAddBlogAndRemoveBlog(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 
-	blog, err := AddBlog(db, "Test", "https://example.com", "", "")
+	blog, err := AddBlog(db, "Test", "https://example.com", "", "", "")
 	if err != nil {
 		t.Fatalf("add blog: %v", err)
 	}
 
-	if _, err := AddBlog(db, "Test", "https://other.com", "", ""); err == nil {
+	if _, err := AddBlog(db, "Test", "https://other.com", "", "", ""); err == nil {
 		t.Fatalf("expected duplicate name error")
 	}
 
-	if _, err := AddBlog(db, "Other", "https://example.com", "", ""); err == nil {
+	if _, err := AddBlog(db, "Other", "https://example.com", "", "", ""); err == nil {
 		t.Fatalf("expected duplicate url error")
 	}
 
@@ -34,7 +34,7 @@ func TestArticleReadUnread(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 
-	blog, err := AddBlog(db, "Test", "https://example.com", "", "")
+	blog, err := AddBlog(db, "Test", "https://example.com", "", "", "")
 	if err != nil {
 		t.Fatalf("add blog: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestGetArticlesFilters(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 
-	blog, err := AddBlog(db, "Test", "https://example.com", "", "")
+	blog, err := AddBlog(db, "Test", "https://example.com", "", "", "")
 	if err != nil {
 		t.Fatalf("add blog: %v", err)
 	}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -8,6 +8,7 @@ type Blog struct {
 	URL            string
 	FeedURL        string
 	ScrapeSelector string
+	UserAgent      string
 	LastScanned    *time.Time
 }
 

--- a/internal/rss/rss.go
+++ b/internal/rss/rss.go
@@ -26,9 +26,9 @@ func (e FeedParseError) Error() string {
 	return e.Message
 }
 
-func ParseFeed(feedURL string, timeout time.Duration) ([]FeedArticle, error) {
+func ParseFeed(feedURL string, timeout time.Duration, userAgent string) ([]FeedArticle, error) {
 	client := &http.Client{Timeout: timeout}
-	response, err := client.Get(feedURL)
+	response, err := getWithOptionalUserAgent(client, feedURL, userAgent)
 	if err != nil {
 		return nil, FeedParseError{Message: fmt.Sprintf("failed to fetch feed: %v", err)}
 	}
@@ -60,9 +60,9 @@ func ParseFeed(feedURL string, timeout time.Duration) ([]FeedArticle, error) {
 	return articles, nil
 }
 
-func DiscoverFeedURL(blogURL string, timeout time.Duration) (string, error) {
+func DiscoverFeedURL(blogURL string, timeout time.Duration, userAgent string) (string, error) {
 	client := &http.Client{Timeout: timeout}
-	response, err := client.Get(blogURL)
+	response, err := getWithOptionalUserAgent(client, blogURL, userAgent)
 	if err != nil {
 		return "", nil
 	}
@@ -120,7 +120,7 @@ func DiscoverFeedURL(blogURL string, timeout time.Duration) (string, error) {
 		if resolved == "" {
 			continue
 		}
-		ok, err := isValidFeed(resolved, timeout)
+		ok, err := isValidFeed(resolved, timeout, userAgent)
 		if err == nil && ok {
 			return resolved, nil
 		}
@@ -129,9 +129,9 @@ func DiscoverFeedURL(blogURL string, timeout time.Duration) (string, error) {
 	return "", nil
 }
 
-func isValidFeed(feedURL string, timeout time.Duration) (bool, error) {
+func isValidFeed(feedURL string, timeout time.Duration, userAgent string) (bool, error) {
 	client := &http.Client{Timeout: timeout}
-	response, err := client.Get(feedURL)
+	response, err := getWithOptionalUserAgent(client, feedURL, userAgent)
 	if err != nil {
 		return false, err
 	}
@@ -147,6 +147,17 @@ func isValidFeed(feedURL string, timeout time.Duration) (bool, error) {
 	}
 
 	return len(feed.Items) > 0 || strings.TrimSpace(feed.Title) != "", nil
+}
+
+func getWithOptionalUserAgent(client *http.Client, targetURL string, userAgent string) (*http.Response, error) {
+	request, err := http.NewRequest(http.MethodGet, targetURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(userAgent) != "" {
+		request.Header.Set("User-Agent", userAgent)
+	}
+	return client.Do(request)
 }
 
 func resolveURL(base *url.URL, href string) string {

--- a/internal/rss/rss_test.go
+++ b/internal/rss/rss_test.go
@@ -30,7 +30,7 @@ func TestParseFeed(t *testing.T) {
 	}))
 	defer server.Close()
 
-	articles, err := ParseFeed(server.URL, 2*time.Second)
+	articles, err := ParseFeed(server.URL, 2*time.Second, "")
 	if err != nil {
 		t.Fatalf("parse feed: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestDiscoverFeedURL(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	feedURL, err := DiscoverFeedURL(server.URL, 2*time.Second)
+	feedURL, err := DiscoverFeedURL(server.URL, 2*time.Second, "")
 	if err != nil {
 		t.Fatalf("discover feed: %v", err)
 	}

--- a/internal/rss/rss_test.go
+++ b/internal/rss/rss_test.go
@@ -75,7 +75,7 @@ func TestDiscoverFeedURL_XMLContentType(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	feedURL, err := DiscoverFeedURL(server.URL+"/tag/AI/feed/", 2*time.Second)
+	feedURL, err := DiscoverFeedURL(server.URL+"/tag/AI/feed/", 2*time.Second, "")
 	if err != nil {
 		t.Fatalf("discover feed: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestDiscoverFeedURL_RelSelf(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	feedURL, err := DiscoverFeedURL(server.URL, 2*time.Second)
+	feedURL, err := DiscoverFeedURL(server.URL, 2*time.Second, "")
 	if err != nil {
 		t.Fatalf("discover feed: %v", err)
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -19,12 +19,6 @@ type ScanResult struct {
 	Error       string
 }
 
-var httpUserAgent string
-
-func SetHTTPUserAgent(userAgent string) {
-	httpUserAgent = strings.TrimSpace(userAgent)
-}
-
 func ScanBlog(db *storage.Database, blog model.Blog) ScanResult {
 	var (
 		articles []model.Article
@@ -33,10 +27,7 @@ func ScanBlog(db *storage.Database, blog model.Blog) ScanResult {
 	)
 
 	feedURL := blog.FeedURL
-	effectiveUserAgent := blog.UserAgent
-	if strings.TrimSpace(effectiveUserAgent) == "" {
-		effectiveUserAgent = httpUserAgent
-	}
+	effectiveUserAgent := strings.TrimSpace(blog.UserAgent)
 
 	if feedURL == "" {
 		if discovered, err := rss.DiscoverFeedURL(blog.URL, 30*time.Second, effectiveUserAgent); err == nil && discovered != "" {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -33,8 +33,13 @@ func ScanBlog(db *storage.Database, blog model.Blog) ScanResult {
 	)
 
 	feedURL := blog.FeedURL
+	effectiveUserAgent := blog.UserAgent
+	if strings.TrimSpace(effectiveUserAgent) == "" {
+		effectiveUserAgent = httpUserAgent
+	}
+
 	if feedURL == "" {
-		if discovered, err := rss.DiscoverFeedURL(blog.URL, 30*time.Second, httpUserAgent); err == nil && discovered != "" {
+		if discovered, err := rss.DiscoverFeedURL(blog.URL, 30*time.Second, effectiveUserAgent); err == nil && discovered != "" {
 			feedURL = discovered
 			blog.FeedURL = discovered
 			_ = db.UpdateBlog(blog)
@@ -42,7 +47,7 @@ func ScanBlog(db *storage.Database, blog model.Blog) ScanResult {
 	}
 
 	if feedURL != "" {
-		feedArticles, err := rss.ParseFeed(feedURL, 30*time.Second, httpUserAgent)
+		feedArticles, err := rss.ParseFeed(feedURL, 30*time.Second, effectiveUserAgent)
 		if err != nil {
 			errText = err.Error()
 		} else {
@@ -52,7 +57,7 @@ func ScanBlog(db *storage.Database, blog model.Blog) ScanResult {
 	}
 
 	if len(articles) == 0 && blog.ScrapeSelector != "" {
-		scrapedArticles, err := scraper.ScrapeBlog(blog.URL, blog.ScrapeSelector, 30*time.Second, httpUserAgent)
+		scrapedArticles, err := scraper.ScrapeBlog(blog.URL, blog.ScrapeSelector, 30*time.Second, effectiveUserAgent)
 		if err != nil {
 			if errText != "" {
 				errText = fmt.Sprintf("RSS: %s; Scraper: %s", errText, err.Error())

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Hyaxia/blogwatcher/internal/model"
@@ -18,6 +19,12 @@ type ScanResult struct {
 	Error       string
 }
 
+var httpUserAgent string
+
+func SetHTTPUserAgent(userAgent string) {
+	httpUserAgent = strings.TrimSpace(userAgent)
+}
+
 func ScanBlog(db *storage.Database, blog model.Blog) ScanResult {
 	var (
 		articles []model.Article
@@ -27,7 +34,7 @@ func ScanBlog(db *storage.Database, blog model.Blog) ScanResult {
 
 	feedURL := blog.FeedURL
 	if feedURL == "" {
-		if discovered, err := rss.DiscoverFeedURL(blog.URL, 30*time.Second); err == nil && discovered != "" {
+		if discovered, err := rss.DiscoverFeedURL(blog.URL, 30*time.Second, httpUserAgent); err == nil && discovered != "" {
 			feedURL = discovered
 			blog.FeedURL = discovered
 			_ = db.UpdateBlog(blog)
@@ -35,7 +42,7 @@ func ScanBlog(db *storage.Database, blog model.Blog) ScanResult {
 	}
 
 	if feedURL != "" {
-		feedArticles, err := rss.ParseFeed(feedURL, 30*time.Second)
+		feedArticles, err := rss.ParseFeed(feedURL, 30*time.Second, httpUserAgent)
 		if err != nil {
 			errText = err.Error()
 		} else {
@@ -45,7 +52,7 @@ func ScanBlog(db *storage.Database, blog model.Blog) ScanResult {
 	}
 
 	if len(articles) == 0 && blog.ScrapeSelector != "" {
-		scrapedArticles, err := scraper.ScrapeBlog(blog.URL, blog.ScrapeSelector, 30*time.Second)
+		scrapedArticles, err := scraper.ScrapeBlog(blog.URL, blog.ScrapeSelector, 30*time.Second, httpUserAgent)
 		if err != nil {
 			if errText != "" {
 				errText = fmt.Sprintf("RSS: %s; Scraper: %s", errText, err.Error())

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -25,9 +25,9 @@ func (e ScrapeError) Error() string {
 	return e.Message
 }
 
-func ScrapeBlog(blogURL string, selector string, timeout time.Duration) ([]ScrapedArticle, error) {
+func ScrapeBlog(blogURL string, selector string, timeout time.Duration, userAgent string) ([]ScrapedArticle, error) {
 	client := &http.Client{Timeout: timeout}
-	response, err := client.Get(blogURL)
+	response, err := getWithOptionalUserAgent(client, blogURL, userAgent)
 	if err != nil {
 		return nil, ScrapeError{Message: fmt.Sprintf("failed to fetch page: %v", err)}
 	}
@@ -101,6 +101,17 @@ func extractTitle(link *goquery.Selection, parent *goquery.Selection) string {
 		}
 	}
 	return ""
+}
+
+func getWithOptionalUserAgent(client *http.Client, targetURL string, userAgent string) (*http.Response, error) {
+	request, err := http.NewRequest(http.MethodGet, targetURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(userAgent) != "" {
+		request.Header.Set("User-Agent", userAgent)
+	}
+	return client.Do(request)
 }
 
 func resolveURL(base *url.URL, href string) string {

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -23,7 +23,7 @@ func TestScrapeBlog(t *testing.T) {
 	}))
 	defer server.Close()
 
-	articles, err := ScrapeBlog(server.URL, "article h2 a, .post", 2*time.Second)
+	articles, err := ScrapeBlog(server.URL, "article h2 a, .post", 2*time.Second, "")
 	if err != nil {
 		t.Fatalf("scrape blog: %v", err)
 	}

--- a/internal/storage/database.go
+++ b/internal/storage/database.go
@@ -75,6 +75,7 @@ func (db *Database) init() error {
 			url TEXT NOT NULL UNIQUE,
 			feed_url TEXT,
 			scrape_selector TEXT,
+			user_agent TEXT,
 			last_scanned TIMESTAMP
 		);
 		CREATE TABLE IF NOT EXISTS articles (
@@ -88,18 +89,26 @@ func (db *Database) init() error {
 			FOREIGN KEY (blog_id) REFERENCES blogs(id)
 		);
 	`
-	_, err := db.conn.Exec(schema)
-	return err
+	if _, err := db.conn.Exec(schema); err != nil {
+		return err
+	}
+	if _, err := db.conn.Exec(`ALTER TABLE blogs ADD COLUMN user_agent TEXT`); err != nil {
+		if !strings.Contains(strings.ToLower(err.Error()), "duplicate column") {
+			return err
+		}
+	}
+	return nil
 }
 
 func (db *Database) AddBlog(blog model.Blog) (model.Blog, error) {
 	result, err := db.conn.Exec(
-		`INSERT INTO blogs (name, url, feed_url, scrape_selector, last_scanned)
-		VALUES (?, ?, ?, ?, ?)`,
+		`INSERT INTO blogs (name, url, feed_url, scrape_selector, user_agent, last_scanned)
+		VALUES (?, ?, ?, ?, ?, ?)`,
 		blog.Name,
 		blog.URL,
 		nullIfEmpty(blog.FeedURL),
 		nullIfEmpty(blog.ScrapeSelector),
+		nullIfEmpty(blog.UserAgent),
 		formatTimePtr(blog.LastScanned),
 	)
 	if err != nil {
@@ -114,22 +123,22 @@ func (db *Database) AddBlog(blog model.Blog) (model.Blog, error) {
 }
 
 func (db *Database) GetBlog(id int64) (*model.Blog, error) {
-	row := db.conn.QueryRow(`SELECT id, name, url, feed_url, scrape_selector, last_scanned FROM blogs WHERE id = ?`, id)
+	row := db.conn.QueryRow(`SELECT id, name, url, feed_url, scrape_selector, user_agent, last_scanned FROM blogs WHERE id = ?`, id)
 	return scanBlog(row)
 }
 
 func (db *Database) GetBlogByName(name string) (*model.Blog, error) {
-	row := db.conn.QueryRow(`SELECT id, name, url, feed_url, scrape_selector, last_scanned FROM blogs WHERE name = ?`, name)
+	row := db.conn.QueryRow(`SELECT id, name, url, feed_url, scrape_selector, user_agent, last_scanned FROM blogs WHERE name = ?`, name)
 	return scanBlog(row)
 }
 
 func (db *Database) GetBlogByURL(url string) (*model.Blog, error) {
-	row := db.conn.QueryRow(`SELECT id, name, url, feed_url, scrape_selector, last_scanned FROM blogs WHERE url = ?`, url)
+	row := db.conn.QueryRow(`SELECT id, name, url, feed_url, scrape_selector, user_agent, last_scanned FROM blogs WHERE url = ?`, url)
 	return scanBlog(row)
 }
 
 func (db *Database) ListBlogs() ([]model.Blog, error) {
-	rows, err := db.conn.Query(`SELECT id, name, url, feed_url, scrape_selector, last_scanned FROM blogs ORDER BY name`)
+	rows, err := db.conn.Query(`SELECT id, name, url, feed_url, scrape_selector, user_agent, last_scanned FROM blogs ORDER BY name`)
 	if err != nil {
 		return nil, err
 	}
@@ -150,11 +159,12 @@ func (db *Database) ListBlogs() ([]model.Blog, error) {
 
 func (db *Database) UpdateBlog(blog model.Blog) error {
 	_, err := db.conn.Exec(
-		`UPDATE blogs SET name = ?, url = ?, feed_url = ?, scrape_selector = ?, last_scanned = ? WHERE id = ?`,
+		`UPDATE blogs SET name = ?, url = ?, feed_url = ?, scrape_selector = ?, user_agent = ?, last_scanned = ? WHERE id = ?`,
 		blog.Name,
 		blog.URL,
 		nullIfEmpty(blog.FeedURL),
 		nullIfEmpty(blog.ScrapeSelector),
+		nullIfEmpty(blog.UserAgent),
 		formatTimePtr(blog.LastScanned),
 		blog.ID,
 	)
@@ -360,9 +370,10 @@ func scanBlog(scanner interface{ Scan(dest ...any) error }) (*model.Blog, error)
 		url            string
 		feedURL        sql.NullString
 		scrapeSelector sql.NullString
+		userAgent      sql.NullString
 		lastScanned    sql.NullString
 	)
-	if err := scanner.Scan(&id, &name, &url, &feedURL, &scrapeSelector, &lastScanned); err != nil {
+	if err := scanner.Scan(&id, &name, &url, &feedURL, &scrapeSelector, &userAgent, &lastScanned); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
@@ -375,6 +386,7 @@ func scanBlog(scanner interface{ Scan(dest ...any) error }) (*model.Blog, error)
 		URL:            url,
 		FeedURL:        feedURL.String,
 		ScrapeSelector: scrapeSelector.String,
+		UserAgent:      userAgent.String,
 	}
 	if lastScanned.Valid {
 		if parsed, err := parseTime(lastScanned.String); err == nil {

--- a/internal/storage/database.go
+++ b/internal/storage/database.go
@@ -53,6 +53,10 @@ func OpenDatabase(path string) (*Database, error) {
 		_ = conn.Close()
 		return nil, err
 	}
+	if err := db.migrate(); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
 	return db, nil
 }
 
@@ -89,12 +93,57 @@ func (db *Database) init() error {
 			FOREIGN KEY (blog_id) REFERENCES blogs(id)
 		);
 	`
-	if _, err := db.conn.Exec(schema); err != nil {
-		return err
+	_, err := db.conn.Exec(schema)
+	return err
+}
+
+// migrate adds new columns for existing databases.
+// Only list columns added AFTER the initial release here.
+// Columns already defined in the CREATE TABLE statement inside init()
+// do not need to be listed — they are created automatically on first run.
+//
+// To add a new column migration, append an entry to the map, e.g.:
+//
+//	"articles": {
+//		{"categories", "TEXT"},
+//	},
+func (db *Database) migrate() error {
+	type col struct{ name, colType string }
+	migrations := map[string][]col{
+		"blogs": {
+			{"user_agent", "TEXT"},
+		},
 	}
-	if _, err := db.conn.Exec(`ALTER TABLE blogs ADD COLUMN user_agent TEXT`); err != nil {
-		if !strings.Contains(strings.ToLower(err.Error()), "duplicate column") {
+	for table, cols := range migrations {
+		// Fetch all existing columns for this table.
+		existing := map[string]bool{}
+		rows, err := db.conn.Query(fmt.Sprintf("PRAGMA table_info('%s')", table))
+		if err != nil {
 			return err
+		}
+		for rows.Next() {
+			var cid int
+			var name, colType string
+			var notnull int
+			var dflt interface{}
+			var pk int
+			if err := rows.Scan(&cid, &name, &colType, &notnull, &dflt, &pk); err != nil {
+				rows.Close()
+				return err
+			}
+			existing[name] = true
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		// Add only the columns that are missing.
+		for _, c := range cols {
+			if !existing[c.name] {
+				if _, err := db.conn.Exec(fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", table, c.name, c.colType)); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	return nil

--- a/internal/storage/database_test.go
+++ b/internal/storage/database_test.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"database/sql"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -367,5 +369,76 @@ func TestLookupHelpers(t *testing.T) {
 	}
 	if exists, err := db.ArticleExists("https://example.com/missing"); err != nil || exists {
 		t.Fatalf("expected missing article to not exist")
+	}
+}
+
+func TestMigrateAddsMissingColumns(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "old.db")
+
+	// Create an old-style database without user_agent column.
+	conn, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open raw connection: %v", err)
+	}
+	_, err = conn.Exec(`
+		CREATE TABLE blogs (
+			id INTEGER PRIMARY KEY,
+			name TEXT NOT NULL,
+			url TEXT NOT NULL UNIQUE,
+			feed_url TEXT,
+			scrape_selector TEXT,
+			last_scanned TIMESTAMP
+		);
+		CREATE TABLE articles (
+			id INTEGER PRIMARY KEY,
+			blog_id INTEGER NOT NULL,
+			title TEXT NOT NULL,
+			url TEXT NOT NULL UNIQUE,
+			published_date TIMESTAMP,
+			discovered_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			is_read BOOLEAN DEFAULT FALSE,
+			FOREIGN KEY (blog_id) REFERENCES blogs(id)
+		);
+	`)
+	if err != nil {
+		t.Fatalf("create old schema: %v", err)
+	}
+	conn.Close()
+
+	// Open with the new code — should trigger migrate().
+	db, err := OpenDatabase(path)
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	defer db.Close()
+
+	// Verify user_agent column now exists and is usable.
+	conn, err = sql.Open("sqlite", fmt.Sprintf("file:%s", path))
+	if err != nil {
+		t.Fatalf("reopen raw connection: %v", err)
+	}
+	defer conn.Close()
+
+	var count int
+	err = conn.QueryRow("SELECT COUNT(*) FROM pragma_table_info('blogs') WHERE name = 'user_agent'").Scan(&count)
+	if err != nil {
+		t.Fatalf("query pragma_table_info: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected user_agent column to exist after migration, got count=%d", count)
+	}
+
+	// Verify the column works end-to-end by inserting and reading a blog.
+	blog, err := db.AddBlog(model.Blog{Name: "Test", URL: "https://example.com", UserAgent: "MyBot/1.0"})
+	if err != nil {
+		t.Fatalf("add blog: %v", err)
+	}
+	got, err := db.GetBlog(blog.ID)
+	if err != nil {
+		t.Fatalf("get blog: %v", err)
+	}
+	if got.UserAgent != "MyBot/1.0" {
+		t.Fatalf("expected user_agent 'MyBot/1.0', got %q", got.UserAgent)
 	}
 }


### PR DESCRIPTION
## Summary
- add per-blog `--user-agent` on `blogwatcher add` (similar to `--scrape-selector`)
- remove global `--user-agent` to keep behavior simple and explicit
- scanning now uses per-blog UA only (or default UA if not configured)

## Why
Different sites may require different User-Agent values. Per-blog settings are clearer and avoid confusing precedence rules.

## Changes
- model/storage:
  - add `user_agent` field to `Blog`
  - add `user_agent` column in DB schema (with migration via `ALTER TABLE ... ADD COLUMN`)
- CLI:
  - `blogwatcher add ... --user-agent "..."` to persist per-blog UA
  - `blogwatcher blogs` now prints configured per-blog UA
  - removed global `--user-agent` flag
- scanner:
  - use only blog-specific UA when present
  - pass effective UA to feed discovery, feed fetch, and scraper fetch
- docs:
  - README examples for per-blog UA

## Verification
- `go test ./...` passes
- `blogwatcher --help` no longer shows global `--user-agent`
