### PR TITLE
feat(storage): support BLOGWATCHER_DB override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ go run ./cmd/blogwatcher ...
 ## Architecture
 
 ### Database
-SQLite database stored at `~/.blogwatcher/blogwatcher.db` with two tables:
+SQLite database stored at `~/.blogwatcher/blogwatcher.db` by default (override with `BLOGWATCHER_DB`) with two tables:
 - `blogs` - Tracked blogs (name, url, feed_url, scrape_selector, last_scanned)
 - `articles` - Discovered articles (blog_id, title, url, published_date, discovered_date, is_read)
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,17 @@ When RSS isn't available, provide a CSS selector that matches article links:
 
 ## Database
 
-BlogWatcher stores data in SQLite at `~/.blogwatcher/blogwatcher.db`:
+By default, BlogWatcher stores data in SQLite at `~/.blogwatcher/blogwatcher.db`.
+
+To isolate independent blog lists (for example, to avoid accidental `read-all` across unrelated sets), set `BLOGWATCHER_DB`:
+
+```bash
+BLOGWATCHER_DB="$HOME/.blogwatcher/work.db" blogwatcher scan
+```
+
+With `BLOGWATCHER_DB` unset or empty, BlogWatcher falls back to the default path.
+
+Database tables:
 
 -   **blogs** - Tracked blogs (name, URL, feed URL, scrape selector)
 -   **articles** - Discovered articles (title, URL, dates, read status)

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,7 +9,7 @@ description: Use when managing or interacting with favorite blogs via the BlogWa
 - Use the Cobra entry point in `cmd/blogwatcher/main.go` and `internal/cli/`.
 - Route business logic through `internal/controller` and persistence through `internal/storage`.
 - Use scanning pipeline packages in `internal/scanner`, `internal/rss`, and `internal/scraper`.
-- Remember the default SQLite path is `~/.blogwatcher/blogwatcher.db` and is created on demand.
+- Remember the default SQLite path is `~/.blogwatcher/blogwatcher.db` (override with `BLOGWATCHER_DB`) and is created on demand.
 
 ## Run Commands
 - Run locally with `go run ./cmd/blogwatcher ...`.

--- a/internal/storage/database.go
+++ b/internal/storage/database.go
@@ -15,8 +15,13 @@ import (
 )
 
 const sqliteTimeLayout = time.RFC3339Nano
+const dbPathEnvVar = "BLOGWATCHER_DB"
 
 func DefaultDBPath() (string, error) {
+	if override := strings.TrimSpace(os.Getenv(dbPathEnvVar)); override != "" {
+		return override, nil
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err

--- a/internal/storage/database_test.go
+++ b/internal/storage/database_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -82,6 +83,46 @@ func TestDatabaseCreatesFileAndCRUD(t *testing.T) {
 	}
 	if !deleted {
 		t.Fatalf("expected blog removal")
+	}
+}
+
+func TestDefaultDBPathUsesEnvOverride(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "isolated", "blogwatcher.db")
+	t.Setenv("BLOGWATCHER_DB", path)
+
+	got, err := DefaultDBPath()
+	if err != nil {
+		t.Fatalf("resolve default db path: %v", err)
+	}
+	if got != path {
+		t.Fatalf("expected env override path %q, got %q", path, got)
+	}
+
+	db, err := OpenDatabase("")
+	if err != nil {
+		t.Fatalf("open database with env override: %v", err)
+	}
+	defer db.Close()
+
+	if db.Path() != path {
+		t.Fatalf("expected database path %q, got %q", path, db.Path())
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected overridden db file to exist: %v", err)
+	}
+}
+
+func TestDefaultDBPathFallsBackWhenEnvIsEmpty(t *testing.T) {
+	t.Setenv("BLOGWATCHER_DB", "")
+
+	got, err := DefaultDBPath()
+	if err != nil {
+		t.Fatalf("resolve default db path: %v", err)
+	}
+
+	expectedSuffix := filepath.Join(".blogwatcher", "blogwatcher.db")
+	if !strings.HasSuffix(got, expectedSuffix) {
+		t.Fatalf("expected default path to end with %q, got %q", expectedSuffix, got)
 	}
 }
 


### PR DESCRIPTION
## Why
Blogwatcher currently stores everything in a single `~/.blogwatcher/blogwatcher.db`.

That makes isolation between independent blog lists difficult and increases risk for broad operations like `read-all` (including agent-driven usage), where one context can accidentally affect another.

## What changed
- Added `BLOGWATCHER_DB` as a default DB path override.
- `DefaultDBPath()` now:
  - uses `BLOGWATCHER_DB` when it is set to a non-empty value
  - falls back to `~/.blogwatcher/blogwatcher.db` when unset/empty
- Kept CLI behavior unchanged (`OpenDatabase("")` still works across commands; it now resolves through the env-aware default path).
- Updated docs to describe the override and isolation use case.

## Tests
- Added `TestDefaultDBPathUsesEnvOverride`
- Added `TestDefaultDBPathFallsBackWhenEnvIsEmpty`
- Verified `go test ./...`

## Smoke test
Validated against:
- Releases page: https://github.com/Hyaxia/blogwatcher/releases
- Feed: https://github.com/Hyaxia/blogwatcher/releases.atom

Using isolated DB path:
- `BLOGWATCHER_DB=/tmp/blogwatcher-smoke.db ... add`
- `... scan`
- `... articles --all`

Observed 2 release entries (`v0.0.2`, `v0.0.1`) stored in the isolated DB, and a separate DB path showed no shared articles.

## Backward compatibility
No breaking change: if `BLOGWATCHER_DB` is not set (or empty), behavior remains unchanged.
