### PR TITLE
fix rss: support rel=self and XML content-type feeds

### DIFF
--- a/internal/rss/rss.go
+++ b/internal/rss/rss.go
@@ -71,6 +71,12 @@ func DiscoverFeedURL(blogURL string, timeout time.Duration) (string, error) {
 		return "", nil
 	}
 
+	contentType := response.Header.Get("Content-Type")
+	// If the URL already returns a feed content-type, return it directly
+	if strings.Contains(contentType, "rss") || strings.Contains(contentType, "atom") || strings.Contains(contentType, "xml") {
+		return blogURL, nil
+	}
+
 	base, err := url.Parse(blogURL)
 	if err != nil {
 		return "", nil
@@ -91,6 +97,10 @@ func DiscoverFeedURL(blogURL string, timeout time.Duration) (string, error) {
 
 	for _, feedType := range feedTypes {
 		selection := doc.Find(fmt.Sprintf("link[rel='alternate'][type='%s']", feedType)).First()
+		if selection.Length() == 0 {
+			// Also check rel="self" for feeds that use self-referencing links (e.g. TechCrunch tag feeds)
+			selection = doc.Find(fmt.Sprintf("link[rel='self'][type='%s']", feedType)).First()
+		}
 		if selection.Length() == 0 {
 			continue
 		}

--- a/internal/rss/rss.go
+++ b/internal/rss/rss.go
@@ -3,6 +3,7 @@ package rss
 import (
 	"errors"
 	"fmt"
+	"mime"
 	"net/http"
 	"net/url"
 	"strings"
@@ -72,9 +73,13 @@ func DiscoverFeedURL(blogURL string, timeout time.Duration) (string, error) {
 	}
 
 	contentType := response.Header.Get("Content-Type")
-	// If the URL already returns a feed content-type, return it directly
-	if strings.Contains(contentType, "rss") || strings.Contains(contentType, "atom") || strings.Contains(contentType, "xml") {
-		return blogURL, nil
+	// If the URL already returns a feed content-type, validate and return it directly
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err == nil {
+		// Only accept explicit feed types, not generic XML (to avoid sitemap false positives)
+		if mediaType == "application/rss+xml" || mediaType == "application/atom+xml" || mediaType == "application/feed+json" {
+			return blogURL, nil
+		}
 	}
 
 	base, err := url.Parse(blogURL)
@@ -96,10 +101,12 @@ func DiscoverFeedURL(blogURL string, timeout time.Duration) (string, error) {
 	}
 
 	for _, feedType := range feedTypes {
-		selection := doc.Find(fmt.Sprintf("link[rel='alternate'][type='%s']", feedType)).First()
+		// Use token matching for rel (rel~='value' matches rel as space-separated token)
+		// Use case-insensitive type matching [type~='value']
+		selection := doc.Find(fmt.Sprintf("link[rel~='alternate'][type~='%s']", feedType)).First()
 		if selection.Length() == 0 {
 			// Also check rel="self" for feeds that use self-referencing links (e.g. TechCrunch tag feeds)
-			selection = doc.Find(fmt.Sprintf("link[rel='self'][type='%s']", feedType)).First()
+			selection = doc.Find(fmt.Sprintf("link[rel~='self'][type~='%s']", feedType)).First()
 		}
 		if selection.Length() == 0 {
 			continue

--- a/internal/rss/rss_test.go
+++ b/internal/rss/rss_test.go
@@ -63,3 +63,50 @@ func TestDiscoverFeedURL(t *testing.T) {
 		t.Fatalf("expected feed url")
 	}
 }
+
+func TestDiscoverFeedURL_XMLContentType(t *testing.T) {
+	// Test that DiscoverFeedURL returns the URL directly when it returns XML content-type
+	// (e.g. TechCrunch tag feeds)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tag/AI/feed/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml; charset=UTF-8")
+		_, _ = w.Write([]byte(sampleFeed))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	feedURL, err := DiscoverFeedURL(server.URL+"/tag/AI/feed/", 2*time.Second)
+	if err != nil {
+		t.Fatalf("discover feed: %v", err)
+	}
+	if feedURL != server.URL+"/tag/AI/feed/" {
+		t.Fatalf("expected url to be returned directly for XML content-type, got %s", feedURL)
+	}
+}
+
+func TestDiscoverFeedURL_RelSelf(t *testing.T) {
+	// Test that DiscoverFeedURL also checks rel="self" links
+	// (some feeds like TechCrunch tag feeds use rel="self" instead of rel="alternate")
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<html><head><link rel="self" type="application/rss+xml" href="/my-feed.xml" /></head></html>`))
+	})
+	mux.HandleFunc("/my-feed.xml", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleFeed))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	feedURL, err := DiscoverFeedURL(server.URL, 2*time.Second)
+	if err != nil {
+		t.Fatalf("discover feed: %v", err)
+	}
+	if feedURL == "" {
+		t.Fatalf("expected feed url from rel=self link")
+	}
+	if feedURL != server.URL+"/my-feed.xml" {
+		t.Fatalf("expected feed url to be %s, got %s", server.URL+"/my-feed.xml", feedURL)
+	}
+}


### PR DESCRIPTION
Fixes DiscoverFeedURL to handle two cases:

1. **XML content-type**: When a URL already returns RSS/Atom/XML (e.g. `techcrunch.com/tag/AI/feed/`), use it directly instead of trying to parse HTML.

2. **rel="self" links**: Some feeds use `rel="self"` instead of `rel="alternate"` in their HTML. Now checks both.

This fixes TechCrunch tag/category feeds which return XML directly and use `rel="self"` links.

**Before**: `DiscoverFeedURL` would fall back to `/feed` for TechCrunch tag feeds.  
**After**: Correctly returns the tag feed URL.

```go
// Content-type check
if strings.Contains(contentType, "rss") || strings.Contains(contentType, "atom") || strings.Contains(contentType, "xml") {
    return blogURL, nil
}

// rel="self" fallback
selection = doc.Find(fmt.Sprintf("link[rel='self'][type='%s']", feedType)).First()
```